### PR TITLE
Fixed meals-showcase section

### DIFF
--- a/style.css
+++ b/style.css
@@ -268,6 +268,8 @@ body {
 .meals-showcase {
   list-style: none;
   width: 100%;
+  padding:0%;
+  margin: 0%;
 }
 
 .meals-showcase li {


### PR DESCRIPTION
Found the problem in margins and paddings.
Corrected Margin and padding of the section components.

![fixed2](https://github.com/khushi-joshi-05/Food-ordering-website/assets/125960660/cefecf3b-fe25-44f6-a1b4-0c273de58edf)

![fixed1](https://github.com/khushi-joshi-05/Food-ordering-website/assets/125960660/48b5cb83-0245-419a-8b00-954a22df2749)

Please assign it to me under GSSoC'24
Please consider merging if you like the work.

Thank you @khushi-joshi-05 @sunny0625 

fixes #414 
