### PR TITLE
remove padding from app_download div.

### DIFF
--- a/Css-files/style.css
+++ b/Css-files/style.css
@@ -299,7 +299,7 @@ body {
     height: 320px;
     color: white;
     padding-left: 50px;
-    padding-top: 80px;
+   
 }
 
 .app_download h4 {

--- a/style.css
+++ b/style.css
@@ -326,7 +326,7 @@ body {
   height: 320px;
   color: white;
   padding-left: 50px;
-  padding-top: 80px;
+ 
 }
 
 .app_download h4 {


### PR DESCRIPTION
# Removal of Padding from app_download Div

#Details:

The app_download div previously had padding applied to its interior space.

By removing the padding, the elements inside the app_download div now occupy the full available space.

![Screenshot from 2024-05-23 14-00-50](https://github.com/khushi-joshi-05/Food-ordering-website/assets/137433025/b23d071f-440d-44a5-85b4-d273837954e7)

![Screenshot from 2024-05-23 14-01-16](https://github.com/khushi-joshi-05/Food-ordering-website/assets/137433025/06fdc9bc-fc10-41c5-bf29-4bdb599d4b68)

