### PR TITLE
Add dynamic copyright year script to footer

### DIFF
--- a/Html-files/ContactUpdate.html
+++ b/Html-files/ContactUpdate.html
@@ -235,7 +235,7 @@
         <p>Stay connected with us on social media for the latest updates, recipes, and foodie adventures.
         </p>
         <div class="copyright">
-          &copy; 2024 Foodies - All Rights Reserved | <span id="author">
+          &copy; <span id="copyright-year"></span> Foodies - All Rights Reserved | <span id="author">
             <a href="https://www.linkedin.com/in/khushi-joshi-95a587256/" target="_blank">Khushi Joshi</a>
           </span></p>
         </div>
@@ -248,6 +248,7 @@
     style="position: fixed; bottom: 50px; right: 50px; padding: 10px; background-color: brown;"><i
       class="fa-solid fa-angle-up"></i></a>
 
+  <script>document.getElementById("copyright-year").textContent = new Date().getFullYear();</script>
 
   <!-- JS Libraries -->
   <script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2.9.2/dist/umd/popper.min.js"></script>

--- a/Html-files/book-table.html
+++ b/Html-files/book-table.html
@@ -154,7 +154,7 @@
                 <p>Stay connected with us on social media for the latest updates, recipes, and foodie adventures.
                 </p>
                 <div class="copyright">
-                    &copy; 2024 Foodies - All Rights Reserved | <span id="author">
+                    &copy; <span id="copyright-year"></span> Foodies - All Rights Reserved | <span id="author">
                         <a href="https://www.linkedin.com/in/khushi-joshi-95a587256/" target="_blank">Khushi Joshi</a>
                     </span></p>
 
@@ -162,6 +162,7 @@
             </div>
         </div>
     </footer>
+    <script>document.getElementById("copyright-year").textContent = new Date().getFullYear();</script>
     <script>
         const HandleSubmit = () => {
             let confirmation_code = Math.floor(Math.random() * 9000);

--- a/Html-files/cart.html
+++ b/Html-files/cart.html
@@ -155,7 +155,7 @@
                 <p>Stay connected with us on social media for the latest updates, recipes, and foodie adventures.</p>
 
                 <div class="copyright">
-                    &copy; 2024 Foodies - All Rights Reserved | <span id="author">
+                    &copy; <span id="copyright-year"></span> Foodies - All Rights Reserved | <span id="author">
                         <a href="https://www.linkedin.com/in/khushi-joshi-95a587256/" target="_blank">Khushi Joshi</a>
                     </span></p>
                 </div>
@@ -163,6 +163,7 @@
         </div>
     </footer>
 
+    <script>document.getElementById("copyright-year").textContent = new Date().getFullYear();</script>
 
     <!-- <script src="../cart.js"></script> -->
     <script src="cart.js">

--- a/Html-files/contact.html
+++ b/Html-files/contact.html
@@ -192,13 +192,14 @@
                 <p>Stay connected with us on social media for the latest updates, recipes, and foodie adventures.
                 </p>
                 <div class="copyright">
-                    &copy; 2024 Foodies - All Rights Reserved | <span id="author">
+                    &copy; <span id="copyright-year"></span> Foodies - All Rights Reserved | <span id="author">
                         <a href="https://www.linkedin.com/in/khushi-joshi-95a587256/" target="_blank">Khushi Joshi</a>
                     </span></p>
                 </div>
             </div>
         </div>
     </footer>
+    <script>document.getElementById("copyright-year").textContent = new Date().getFullYear();</script>
 </body>
 
 </html>

--- a/Html-files/contact_GSSoC_contriburted.html
+++ b/Html-files/contact_GSSoC_contriburted.html
@@ -118,11 +118,12 @@
                 <p>Stay connected with us on social media for the latest updates, recipes, and foodie adventures.
                 </p>
                 <div class="copyright">
-                    &copy; 2024 Foodies . All Rights Reserved. | Developed by Khushi Joshi</p>
+                    &copy; <span id="copyright-year"></span> Foodies . All Rights Reserved. | Developed by Khushi Joshi</p>
 
                 </div>
             </div>
     </footer>
+    <script>document.getElementById("copyright-year").textContent = new Date().getFullYear();</script>
 </body>
 
 </html>

--- a/Html-files/menu.html
+++ b/Html-files/menu.html
@@ -402,7 +402,7 @@
                 <p>Stay connected with us on social media for the latest updates, recipes, and foodie adventures.
                 </p>
                 <div class="copyright">
-                    &copy; 2024 Foodies - All Rights Reserved | <span id="author">
+                    &copy; <span id="copyright-year"></span> Foodies - All Rights Reserved | <span id="author">
                         <a href="https://www.linkedin.com/in/khushi-joshi-95a587256/" target="_blank">Khushi Joshi</a>
                     </span></p>
 
@@ -414,6 +414,8 @@
         </div>
     </footer>
 
+    <script>document.getElementById("copyright-year").textContent = new Date().getFullYear();</script>
+    
     <script src="menu.js">
         function redirectLogin() {
             window.location.href = "login.html";

--- a/Html-files/services.html
+++ b/Html-files/services.html
@@ -253,7 +253,7 @@
                 <p>Stay connected with us on social media for the latest updates, recipes, and foodie adventures.
                 </p>
                 <div class="copyright">
-                    &copy; 2024 Foodies - All Rights Reserved | <span id="author">
+                    &copy; <span id="copyright-year"></span> Foodies - All Rights Reserved | <span id="author">
                         <a href="https://www.linkedin.com/in/khushi-joshi-95a587256/" target="_blank">Khushi Joshi</a>
                     </span></p>
                 </div>
@@ -261,6 +261,7 @@
         </div>
     </footer>
 
+    <script>document.getElementById("copyright-year").textContent = new Date().getFullYear();</script>
 </body>
 
 </html>

--- a/index.html
+++ b/index.html
@@ -403,7 +403,7 @@
                     <p>Stay connected with us on social media for the latest updates, recipes, and foodie adventures.
                     </p>
                     <div class="copyright">
-                        &copy; 2024 Foodies - All Rights Reserved | <span id="author">
+                        &copy; <span id="copyright-year"></span> Foodies - All Rights Reserved | <span id="author">
                             <a href="https://www.linkedin.com/in/khushi-joshi-95a587256/" target="_blank">Khushi
                                 Joshi</a>
                         </span></p>
@@ -422,7 +422,7 @@
         </button>
         <!--Scroll top button finish-->
     </div>
-
+    <script>document.getElementById("copyright-year").textContent = new Date().getFullYear();</script>
     <script>
         const heroSlider = document.querySelector("[data-hero-slider]");
         const heroSliderItems = document.querySelectorAll("[data-hero-slider-item]");
@@ -461,7 +461,7 @@
 
         heroSliderPrevBtn.addEventListener("click", slidePrev);
 
-        // auto slide 
+        // auto slide
 
         let autoSlideInterval;
 


### PR DESCRIPTION
Fixed issue: #674 

- Added a JavaScript script to dynamically set the current year in the footer.
- The script uses the Date object to retrieve the current year and updates the text content of the element with the ID 'copyright-year'.
- This ensures the copyright year is always up-to-date without manual changes.
