### PR TITLE
Fix Overlap Issue Between Scroll to Top Button and WebChat Bot

### DIFF
--- a/Css-files/scroll-top-button.css
+++ b/Css-files/scroll-top-button.css
@@ -8,8 +8,9 @@
 
 .scroll-top-button {
   position: fixed;
-  top: 82%;
-  right: 2.4%;
+  /* top: auto; */
+  bottom: 3.2%;
+  left: 1.4%;
   width: 40px;
   height: 40px;
   display: flex;
@@ -26,15 +27,15 @@
 
 @keyframes bouncing {
   0% {
-    top: 82%;
+    transform: translateY(0);
   }
 
   50% {
-    top: 81%;
+    transform: translateY(-5px);
   }
 
   100% {
-    top: 82%;
+    transform: translateY(0);
   }
 }
 


### PR DESCRIPTION
Hey @khushi-joshi-05 and @sunny0625,
issue closes #812 
This pull request addresses the issue of the "Scroll to Top" button overlapping with the WebChat bot on the website. The overlapping elements affected the usability and accessibility of both features, making it difficult for users to interact with the WebChat bot and the scroll button.

# Changes Made:
- Modified the CSS for the Scroll to Top Button:
- Adjusted the position of the "Scroll to Top" button to avoid overlap.
- Updated the bottom and left properties to position the button appropriately.
- Ensured the button animation does not interfere with the WebChat bot.

#Screenshots : 
![image](https://github.com/khushi-joshi-05/Food-ordering-website/assets/131389695/77acd3eb-2cdc-4c3a-a371-2d5151b08414)

Please take a look and review it.
Also, Please add the labels.