### PR TITLE
Changed the input type for phone number

### DIFF
--- a/Html-files/book-table.html
+++ b/Html-files/book-table.html
@@ -63,7 +63,7 @@
                 </div>
                 <div class="form-group">
                     <label for="name">Phone Number: </label>
-                    <input class="form-control" type="number" name="phone" placeholder="Phone Number" required>
+                    <input class="form-control" type="tel" name="phone" placeholder="Phone Number" required>
                 </div>
                 <div class="form-group">
                     <label for="name">Email: </label>


### PR DESCRIPTION
Fixed issue #722 

The phone number input field in the form is currently set to type="number", which is not ideal for capturing phone numbers. It should be changed to type="tel" for better validation and user experience.