### PR TITLE
Linked contact section properly from footer of services section

### DIFF
--- a/Html-files/services.html
+++ b/Html-files/services.html
@@ -264,7 +264,7 @@
                                     <a class="nav-link" href="../Html-files/services.html">Services</a>
                                 </li>
                                 <li class="nav-item">
-                                    <a class="nav-link" href="../Html-files/offers.html">Contact us</a>
+                                    <a class="nav-link" href="../Html-files/contact.html">Contact us</a>
                                 </li>
                                 <li class="nav-item">
                                     <a class="nav-link" href="../Html-files/cart.html">Cart</a>


### PR DESCRIPTION
fixes #1156 
Linked the Contact us from services section footer.(earlier it was redirected to "offers" on clicking contact us)

Before:

https://github.com/khushi-joshi-05/Food-ordering-website/assets/162733812/bfb576ef-3c98-4fce-bee4-e6babef614b8

After:

https://github.com/khushi-joshi-05/Food-ordering-website/assets/162733812/323040e0-7b43-4ef6-943d-3068e8cd1221

