### PR TITLE
continue shopping redirect to home-page

### DIFF
--- a/Html-files/cart.html
+++ b/Html-files/cart.html
@@ -123,7 +123,9 @@
                     <p>Shipping: $0</p>
                     <p><strong>Total: $149.96</strong></p>
                 </div>
-                <button class="btn btn-outline-primary mt-3">Continue Shopping</button>
+                <a href="../index.html" class="btn btn-outline-primary mt-3">Continue Shopping</a>
+
+
             </div>
             <div class="col-md-5">
                 <h2 class="playfair">Payment Info</h2>


### PR DESCRIPTION
Issue #1248 has been resolved. Now, the "Continue Shopping" button redirects to the homepage correctly.