### PR TITLE
Added Navigation Arrows on the Sides of Carousel

### DIFF
--- a/Css-files/offers.css
+++ b/Css-files/offers.css
@@ -480,6 +480,31 @@ border: 4px solid brown;
   opacity: 1;
 }
 
+button.prev, button.next {
+  position: absolute;
+  top: 50%;
+  margin: 20px;
+  transform: translateY(-50%);
+  background-color: brown;
+  color: white;
+  border: 1px white solid;
+  padding: 10px;
+  cursor: pointer;
+  z-index: 1;
+}
+button.prev {
+  left: 0;
+}
+
+button.next {
+  right: 0;
+}
+
+button.prev:hover, button.next:hover {
+  background-color: white;
+  color: brown;
+  border:1px solid brown;
+}
 
 /*
 ==========================================

--- a/Html-files/offers.html
+++ b/Html-files/offers.html
@@ -300,11 +300,40 @@
                     </div>
                   </div>
                 </div>
+                <button class="prev" onclick="changeSlide(-1)">&#10094;</button>
+                <button class="next" onclick="changeSlide(1)">&#10095;</button>
               </div>
             </div>
           </div>
         </div>
       </div>
+      <script>
+          let currentSlide = 0;
+          const slides = document.querySelectorAll('.carousel-item');
+
+          function showSlide(index) {
+              slides.forEach((slide, i) => {
+                  slide.classList.remove('active');
+                  if (i === index) {
+                      slide.classList.add('active');
+                  }
+              });
+          }
+
+          function changeSlide(direction) {
+              currentSlide += direction;
+              if (currentSlide < 0) {
+                  currentSlide = slides.length - 1;
+              } else if (currentSlide >= slides.length) {
+                  currentSlide = 0;
+              }
+              showSlide(currentSlide);
+          }
+
+          // Initialize the first slide
+          showSlide(currentSlide);
+
+      </script>
     </section>
 
     <!-- footer section -->


### PR DESCRIPTION
## Related Issue
None

## Description
I have added the Navigation Arrows on the sides of carousel under testimonials section in offers page. This helps user to slide through the images via arrow buttons instead of clicking the three dots below.
Now the user can chose either of the way to navigate through testimonial cards.
I've also added CSS to make them go with the theme

## Type of PR

- [ ] Bug fix
- [x] Feature enhancement
- [ ] Documentation update
- [ ] Other (specify): _______________

## Screenshots / videos (if applicable)
Before:
![image](https://github.com/khushi-joshi-05/Food-ordering-website/assets/169376061/fe4988ea-5af9-4bda-86ab-b8d09962fe8a)


After:
![image](https://github.com/khushi-joshi-05/Food-ordering-website/assets/169376061/3b73eef2-ca75-4f37-9bec-d341473c5267)


## Checklist:
- [x] I have performed a self-review of my code
- [x] I have read and followed the Contribution Guidelines.
- [x] I have tested the changes thoroughly before submitting this pull request.
- [x] I have provided relevant issue numbers, screenshots, and videos after making the changes.
- [x] I have commented my code, particularly in hard-to-understand areas.
<!-- [X] - put a cross/X inside [] to check the box -->

## Additional context:
Thank you for assigning me this issue under GSSOC'24.
Please put level label on this PR.
Thank You!
