### PR TITLE
Fix incorrect URL in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ This repository is aimed to help people to contribute in open source and learn G
 
 2. **Clone the Repository**:
    ```bash
-   git clone https://github.com/khushi-joshi-05/FoodOrderingWebsite.git
+   git clone https://github.com/khushi-joshi-05/Food-ordering-website.git
    ```
    This will create a `FoodOrderingWebsite` directory with all project files.
 
@@ -126,7 +126,7 @@ This repository is aimed to help people to contribute in open source and learn G
 ### Create an Issue
 
 1. **Navigate to the GitHub Repository**:
-   - Go to [FoodOrderingWebsite Repository](https://github.com/khushi-joshi-05/FoodOrderingWebsite).
+   - Go to [FoodOrderingWebsite Repository](https://github.com/khushi-joshi-05/Food-ordering-website.git ) .
 
 2. **Open the Issues Tab**:
    - Click on `Issues`.
@@ -140,7 +140,7 @@ This repository is aimed to help people to contribute in open source and learn G
 
 2. **Clone Your Fork**:
    ```bash
-   git clone https://github.com/YOUR_USERNAME/FoodOrderingWebsite.git
+   git clone https://github.com/YOUR_USERNAME/Food-ordering-website.git
    ```
 
 3. **Create a New Branch**:


### PR DESCRIPTION
## Description
This pull request addresses the issue of incorrect URLs in the README file. The incorrect URLs have been updated to point to the correct repositories. This ensures that users can correctly clone the repository and navigate to the relevant pages.

- Updated incorrect repository URLs in the `Clone the Repository` section.
- Updated incorrect repository URLs in the `Navigate to the GitHub Repository` section.
- Updated incorrect repository URLs in the `Clone Your Fork` section.

## Related Issues

[Cite any related issue(s) this pull request addresses. If none, simply state “None”]
- Closes  #1459 

## Type of PR

- [X] Bug fix
- [ ] Feature enhancement
- [X] Documentation update
- [ ] Other (specify): _______________


## Checklist

- [X] I have gone through the [contributing guide](https://github.com/khushi-joshi-05/Food-ordering-website/)
- [X] I have updated my branch and synced it with project `main` branch before making this PR
- [X] I have performed a self-review of my code
- [X] I have tested the changes thoroughly before submitting this pull request.
- [X] I have provided relevant issue numbers, screenshots, and videos after making the changes.
- [X] I have commented my code, particularly in hard-to-understand areas.
<!-- [X] - put a cross/X inside [] to check the box -->

## Additional context:
[Include any additional information or context that might be helpful for reviewers.]
