### PR TITLE
Added Rate Us Menu in all the pages

### DIFF
--- a/Html-files/RateUs.html
+++ b/Html-files/RateUs.html
@@ -78,7 +78,7 @@
                         </a>
                     </li>
                     <li class="nav-item">
-                        <a class="nav-link active" href="../Html-files/menu.html">
+                        <a class="nav-link" href="../Html-files/menu.html">
                             <i class="fas fa-book-open"></i> Menu
                         </a>
                     </li>
@@ -104,7 +104,7 @@
                             <i class="fas fa-tags"></i> Offers
                         </a>
                     </li>
-                    <li class="nav-item">
+                    <li class="nav-item active">
                         <a class="nav-link" href="../Html-files/rateus.html">
                             <i class="fas fa-star"></i> Rate Us
                         </a>

--- a/Html-files/RateUs.html
+++ b/Html-files/RateUs.html
@@ -78,7 +78,7 @@
                         </a>
                     </li>
                     <li class="nav-item">
-                        <a class="nav-link active" href="../Html-files/menu.html">
+                        <a class="nav-link" href="../Html-files/menu.html">
                             <i class="fas fa-book-open"></i> Menu
                         </a>
                     </li>
@@ -105,7 +105,7 @@
                         </a>
                     </li>
                     <li class="nav-item">
-                        <a class="nav-link" href="../Html-files/rateus.html">
+                        <a class="nav-link active" href="../Html-files/rateus.html">
                             <i class="fas fa-star"></i> Rate Us
                         </a>
                     </li>

--- a/Html-files/RateUs.html
+++ b/Html-files/RateUs.html
@@ -104,8 +104,8 @@
                             <i class="fas fa-tags"></i> Offers
                         </a>
                     </li>
-                    <li class="nav-item active">
-                        <a class="nav-link" href="../Html-files/rateus.html">
+                    <li class="nav-item">
+                        <a class="nav-link active" href="../Html-files/rateus.html">
                             <i class="fas fa-star"></i> Rate Us
                         </a>
                     </li>

--- a/Html-files/RateUs.html
+++ b/Html-files/RateUs.html
@@ -78,7 +78,7 @@
                         </a>
                     </li>
                     <li class="nav-item">
-                        <a class="nav-link" href="../Html-files/menu.html">
+                        <a class="nav-link active" href="../Html-files/menu.html">
                             <i class="fas fa-book-open"></i> Menu
                         </a>
                     </li>
@@ -105,7 +105,7 @@
                         </a>
                     </li>
                     <li class="nav-item">
-                        <a class="nav-link active" href="../Html-files/rateus.html">
+                        <a class="nav-link" href="../Html-files/rateus.html">
                             <i class="fas fa-star"></i> Rate Us
                         </a>
                     </li>

--- a/Html-files/cart.html
+++ b/Html-files/cart.html
@@ -175,6 +175,11 @@
                             <li class="nav-item">
                                 <a class="nav-link" href="../Html-files/offers.html"><i class="fa-solid fa-tag"></i> Offers</a>
                             </li>
+                            <li class="nav-item">
+                                <a class="nav-link" href="RateUs.html">
+                                    <i class="fa-solid fa-star"></i> Rate Us
+                                </a>
+                            </li>
                         </ul>
                     </div>
                     <div class="order-0 ml-auto p-2">

--- a/Html-files/cart.html
+++ b/Html-files/cart.html
@@ -175,7 +175,11 @@
                             <li class="nav-item">
                                 <a class="nav-link" href="../Html-files/offers.html"><i class="fa-solid fa-tag"></i> Offers</a>
                             </li>
-                            
+                            <li class="nav-item">
+                                <a class="nav-link" href="RateUs.html">
+                                    <i class="fa-solid fa-star"></i> Rate Us
+                                </a>
+                            </li>
                         </ul>
                     </div>
                     <div class="order-0 ml-auto p-2">

--- a/Html-files/cart.html
+++ b/Html-files/cart.html
@@ -175,11 +175,7 @@
                             <li class="nav-item">
                                 <a class="nav-link" href="../Html-files/offers.html"><i class="fa-solid fa-tag"></i> Offers</a>
                             </li>
-                            <li class="nav-item">
-                                <a class="nav-link" href="RateUs.html">
-                                    <i class="fa-solid fa-star"></i> Rate Us
-                                </a>
-                            </li>
+                            
                         </ul>
                     </div>
                     <div class="order-0 ml-auto p-2">

--- a/Html-files/contact.html
+++ b/Html-files/contact.html
@@ -140,15 +140,15 @@
                 <li><a class="dropdown-item" href="#">FAQS</a></li>
               </ul>
             </li>
-            
+            <li class="nav-item">
+              <a class="nav-link active" href="../Html-files/contact.html"
+                ><i class="fa-solid fa-phone"></i> Contact Us</a
+              >
+            </li>
             <li class="nav-item">
               <a class="nav-link" href="../Html-files/offers.html"><i class="fa-solid fa-tag"></i> Offers</a>
             </li>
-            <li class="nav-item">
-              <a class="nav-link" href="RateUs.html">
-                  <i class="fa-solid fa-star"></i> Rate Us
-              </a>
-            </li>
+            
           </ul>
         </div>
         <div class="order-0 ml-auto p-2">

--- a/Html-files/contact.html
+++ b/Html-files/contact.html
@@ -148,6 +148,11 @@
             <li class="nav-item">
               <a class="nav-link" href="../Html-files/offers.html"><i class="fa-solid fa-tag"></i> Offers</a>
             </li>
+            <li class="nav-item">
+              <a class="nav-link" href="RateUs.html">
+                  <i class="fa-solid fa-star"></i> Rate Us
+              </a>
+            </li>
           </ul>
         </div>
         <div class="order-0 ml-auto p-2">

--- a/Html-files/contact.html
+++ b/Html-files/contact.html
@@ -140,11 +140,7 @@
                 <li><a class="dropdown-item" href="#">FAQS</a></li>
               </ul>
             </li>
-            <li class="nav-item">
-              <a class="nav-link active" href="../Html-files/contact.html"
-                ><i class="fa-solid fa-phone"></i> Contact Us</a
-              >
-            </li>
+            
             <li class="nav-item">
               <a class="nav-link" href="../Html-files/offers.html"><i class="fa-solid fa-tag"></i> Offers</a>
             </li>

--- a/Html-files/contact.html
+++ b/Html-files/contact.html
@@ -148,7 +148,11 @@
             <li class="nav-item">
               <a class="nav-link" href="../Html-files/offers.html"><i class="fa-solid fa-tag"></i> Offers</a>
             </li>
-            
+            <li class="nav-item">
+              <a class="nav-link" href="RateUs.html">
+                  <i class="fa-solid fa-star"></i> Rate Us
+              </a>
+            </li>
           </ul>
         </div>
         <div class="order-0 ml-auto p-2">

--- a/Html-files/login.html
+++ b/Html-files/login.html
@@ -114,11 +114,7 @@
 					<li class="nav-item">
 						<a class="nav-link" href="../Html-files/offers.html"><i class="fa-solid fa-tag"></i> Offers</a>
 					</li>
-					<li class="nav-item">
-						<a class="nav-link" href="RateUs.html">
-							<i class="fa-solid fa-star"></i> Rate Us
-						</a>
-					</li>
+					
 				</ul>
 			</div>
 			<div class="order-0 ml-auto p-2">

--- a/Html-files/login.html
+++ b/Html-files/login.html
@@ -114,7 +114,11 @@
 					<li class="nav-item">
 						<a class="nav-link" href="../Html-files/offers.html"><i class="fa-solid fa-tag"></i> Offers</a>
 					</li>
-					
+					<li class="nav-item">
+						<a class="nav-link" href="RateUs.html">
+							<i class="fa-solid fa-star"></i> Rate Us
+						</a>
+					</li>
 				</ul>
 			</div>
 			<div class="order-0 ml-auto p-2">

--- a/Html-files/login.html
+++ b/Html-files/login.html
@@ -114,6 +114,11 @@
 					<li class="nav-item">
 						<a class="nav-link" href="../Html-files/offers.html"><i class="fa-solid fa-tag"></i> Offers</a>
 					</li>
+					<li class="nav-item">
+						<a class="nav-link" href="RateUs.html">
+							<i class="fa-solid fa-star"></i> Rate Us
+						</a>
+					</li>
 				</ul>
 			</div>
 			<div class="order-0 ml-auto p-2">

--- a/Html-files/offers.html
+++ b/Html-files/offers.html
@@ -204,11 +204,7 @@
                 ><i class="fa-solid fa-tag"></i> Offers</a
               >
             </li>
-            <li class="nav-item">
-              <a class="nav-link" href="RateUs.html">
-                  <i class="fa-solid fa-star"></i> Rate Us
-              </a>
-            </li>
+            
           </ul>
         </div>
         <div class="order-0 ml-auto p-2">

--- a/Html-files/offers.html
+++ b/Html-files/offers.html
@@ -204,6 +204,11 @@
                 ><i class="fa-solid fa-tag"></i> Offers</a
               >
             </li>
+            <li class="nav-item">
+              <a class="nav-link" href="RateUs.html">
+                  <i class="fa-solid fa-star"></i> Rate Us
+              </a>
+            </li>
           </ul>
         </div>
         <div class="order-0 ml-auto p-2">

--- a/Html-files/offers.html
+++ b/Html-files/offers.html
@@ -204,7 +204,11 @@
                 ><i class="fa-solid fa-tag"></i> Offers</a
               >
             </li>
-            
+            <li class="nav-item">
+              <a class="nav-link" href="RateUs.html">
+                  <i class="fa-solid fa-star"></i> Rate Us
+              </a>
+            </li>
           </ul>
         </div>
         <div class="order-0 ml-auto p-2">

--- a/Html-files/services.html
+++ b/Html-files/services.html
@@ -123,6 +123,11 @@
               <li class="nav-item">
                 <a class="nav-link" href="../Html-files/offers.html"><i class="fa-solid fa-tag"></i> Offers</a>
                     </li>
+                    <li class="nav-item">
+                        <a class="nav-link" href="RateUs.html">
+                            <i class="fa-solid fa-star"></i> Rate Us
+                        </a>
+                      </li>
                     </ul>
                 </div>
                 <div class="order-0 ml-auto p-2">

--- a/Html-files/services.html
+++ b/Html-files/services.html
@@ -123,7 +123,11 @@
               <li class="nav-item">
                 <a class="nav-link" href="../Html-files/offers.html"><i class="fa-solid fa-tag"></i> Offers</a>
                     </li>
-                    
+                    <li class="nav-item">
+                        <a class="nav-link" href="RateUs.html">
+                            <i class="fa-solid fa-star"></i> Rate Us
+                        </a>
+                    </li>
                     </ul>
                 </div>
                 <div class="order-0 ml-auto p-2">

--- a/Html-files/services.html
+++ b/Html-files/services.html
@@ -123,11 +123,7 @@
               <li class="nav-item">
                 <a class="nav-link" href="../Html-files/offers.html"><i class="fa-solid fa-tag"></i> Offers</a>
                     </li>
-                    <li class="nav-item">
-                        <a class="nav-link" href="RateUs.html">
-                            <i class="fa-solid fa-star"></i> Rate Us
-                        </a>
-                      </li>
+                    
                     </ul>
                 </div>
                 <div class="order-0 ml-auto p-2">

--- a/Html-files/signup.html
+++ b/Html-files/signup.html
@@ -114,11 +114,7 @@
 					<li class="nav-item">
 						<a class="nav-link" href="../Html-files/offers.html"><i class="fa-solid fa-tag"></i> Offers</a>
 					</li>
-					<li class="nav-item">
-						<a class="nav-link" href="RateUs.html">
-							<i class="fa-solid fa-star"></i> Rate Us
-						</a>
-					</li>
+					
 				</ul>
 			</div>
 			<div class="order-0 ml-auto p-2">

--- a/Html-files/signup.html
+++ b/Html-files/signup.html
@@ -114,7 +114,11 @@
 					<li class="nav-item">
 						<a class="nav-link" href="../Html-files/offers.html"><i class="fa-solid fa-tag"></i> Offers</a>
 					</li>
-					
+					<li class="nav-item">
+						<a class="nav-link" href="RateUs.html">
+							<i class="fa-solid fa-star"></i> Rate Us
+						</a>
+					</li>
 				</ul>
 			</div>
 			<div class="order-0 ml-auto p-2">

--- a/Html-files/signup.html
+++ b/Html-files/signup.html
@@ -114,6 +114,11 @@
 					<li class="nav-item">
 						<a class="nav-link" href="../Html-files/offers.html"><i class="fa-solid fa-tag"></i> Offers</a>
 					</li>
+					<li class="nav-item">
+						<a class="nav-link" href="RateUs.html">
+							<i class="fa-solid fa-star"></i> Rate Us
+						</a>
+					</li>
 				</ul>
 			</div>
 			<div class="order-0 ml-auto p-2">

--- a/index.html
+++ b/index.html
@@ -135,13 +135,6 @@
                         <a class="nav-link" href="Html-files/offers.html">
 
                             <i class="fa-solid fa-tag"></i> Offers
-
-
-                        
-
-
-                            
-
                         </a>
                     </li>
 


### PR DESCRIPTION
Fixed #1496 

# Description
I have addressed this issue successfully by adding the 'Rate Us' menu on the Nav Bar of all the pages:
- Services 
![after3](https://github.com/user-attachments/assets/107a0d35-69a6-4e9d-b56b-e3bd6bf08f1f)

- Contact Us
![after2](https://github.com/user-attachments/assets/2790681b-5d98-4fd4-8899-2e503fed8c94)

- Offers
![after1](https://github.com/user-attachments/assets/1c60be63-3282-48df-8732-cd6ab10f8c92)

- Login
![after5](https://github.com/user-attachments/assets/d84f8690-b52e-468f-81f5-5bea37374190)

- Sign-up
![after6](https://github.com/user-attachments/assets/6b44d930-2275-4ff6-8a5b-55ad27e854a9)

- Cart
![after4](https://github.com/user-attachments/assets/c8d8c166-2a52-4c1f-8c85-2954a97c0853)


This will allow the users to easily navigate to the 'Rate Us' page.

### Fixed Active Nav
I also fixed the active nav on the Rate Us page.

Before:

![rateus1](https://github.com/user-attachments/assets/8bc6302a-de73-49bd-826a-96bca68ea575)

After:

![rateUsactive](https://github.com/user-attachments/assets/269c444d-5eea-41fd-bbf8-36fa65a970cc)
