### PR TITLE
Navigate to the Home page from the Menu page.

### DIFF
--- a/Html-files/menu.html
+++ b/Html-files/menu.html
@@ -126,7 +126,7 @@
         <div class="collapse navbar-collapse hamburgeritems centerdiv order-2 order-lg-0">
             <ul class="navbar-nav center-links">
                 <li class="nav-item">
-                    <a class="nav-link" aria-current="page" href="../index.html">
+                    <a class="nav-link" aria-current="page" href="..\index.html">
                         <i class="fa-solid fa-home"></i> Home
                     </a>
                 </li>


### PR DESCRIPTION
## Description

When we are on menu page and click on home page we were not able to navigate back to home page. I have fixed the issue and now  when we are on menu page and click on home page we are able to navigate to the home page.

Issue No: #1477 

## Related Issues

- Closes #1477

## Type of PR

- [x] Bug fix


## Screenshots / videos (if applicable)
 Before :

https://github.com/user-attachments/assets/4b0a1b65-6979-4d57-9d7d-622d19ff55cb

After:


https://github.com/user-attachments/assets/52a8c7c7-1558-4add-8932-2c34b1b326e3




## Checklist

- [x] I have gone through the [contributing guide](https://github.com/khushi-joshi-05/Food-ordering-website/)
- [x] I have updated my branch and synced it with project `main` branch before making this PR
- [x] I have performed a self-review of my code
- [x] I have tested the changes thoroughly before submitting this pull request.
- [x] I have provided relevant issue numbers, screenshots, and videos after making the changes.
- [x] I have commented my code, particularly in hard-to-understand areas.


