### PR TITLE
Fix: Correct Formatting of "Follow Us" Line in Footer Section

### DIFF
--- a/Css-files/footer.css
+++ b/Css-files/footer.css
@@ -51,11 +51,13 @@ footer {
 }
 
 .footer-content {
-  text-align: start;
+  width: 100%;
+  max-width: 1200px; /* Control max width */
+  margin: 0 auto; /* Center the footer content */
   display: flex;
   flex-direction: column;
-  align-items: start;
-  padding-left: 1rem;
+  align-items: center; /* Center children horizontally */
+  justify-content: center;
 }
 
 .foot-panel1 .nav-link {
@@ -160,8 +162,10 @@ footer {
 
 .follow-us {
   font-size: 1.5rem;
-  margin: 0 45.5%;
-  margin-bottom: 20px;
+  margin: 0; /* Adjusted margin */
+  padding: 0 15px; /* Optional padding */
+  text-align: center; /* Center the text */
+  white-space: nowrap; /* Prevent text from breaking into a new line */
   transition: color 0.3s ease;
 }
 


### PR DESCRIPTION
### Summary
This pull request addresses issue #1607 by correcting the formatting of the "Follow Us" line in the Footer section. The text for social contacts was not properly aligned and displayed on multiple lines. This fix ensures that the text appears on a single line as intended.

### Changes Made
- Updated CSS styles to ensure the "Follow Us" line in the Footer section is displayed on one line.
- Adjusted layout to align social contact links horizontally.

### Issue
- **Issue #1607**: Follow Us line for social contact in the Footer section is not properly formatted; the text should appear in one line.

### Testing
- Verified that the "Follow Us" line appears correctly on different screen sizes and devices.
- Ensured that all social contact links are aligned horizontally and are easily readable.

### Screenshots
<img width="1128" alt="Screenshot 2024-08-13 at 00 39 41" src="https://github.com/user-attachments/assets/33aabd9d-908e-40cc-afb2-237ea556988b">


### Additional Notes
- No functional changes were made; only the appearance of the Footer section was adjusted.
